### PR TITLE
将原有版本8u181-jre改为8u212-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u181-jre
+FROM openjdk:8u212-jdk
 MAINTAINER Alpha Hinex <AlphaHinex@gmail.com>
 
 RUN apt-get update \


### PR DESCRIPTION
为了满足监控的需求
支持jcmd 所以将原有OpenJRE镜像换成OpenJDK镜像