### PR TITLE
[完美]openJRE-8升级至openJdk11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u181-jre
+FROM openjdk:11.0.3-jdk
 MAINTAINER Alpha Hinex <AlphaHinex@gmail.com>
 
 RUN apt-get update \
@@ -16,7 +16,7 @@ RUN curl -o /usr/lib/alpn-boot-8.1.12.v20180117.jar https://repo.gradle.org/grad
 # Install the Java JCE Policy
 # Based on https://github.com/commitd/docker-java-jce/blob/master/Dockerfile
 RUN curl -q -L -C - -b "oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-8.zip -O http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip \
-    && unzip -oj -d /docker-java-home/jre/lib/security /tmp/jce_policy-8.zip \*/\*.jar \
+    && unzip -oj -d /docker-java-home/lib/security /tmp/jce_policy-8.zip \*/\*.jar \
     && rm /tmp/jce_policy-8.zip
 
 ENV LANG zh_CN.UTF-8


### PR DESCRIPTION
为使用jdk自带监控采集功能
采用openJdk11.0.3版本
支持jcmd，JFR，VM,GC等收集
建立docker镜像
JCE地址修改至/docker-java-home/lib/security